### PR TITLE
Add setText to editor.js

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1535,6 +1535,11 @@ You should have received a copy of the GNU General Public License along with thi
 			return src;
 		},
 
+		setText: function(newText){
+			//Function to set the source code
+			$('#contentarea').html(newText);
+		},
+
 		setStyleWithCSS:function(){
 			if(navigator.userAgent.match(/MSIE/i)){	//for IE10
 				try {


### PR DESCRIPTION
There's a getText function that allow us to get html source code from the control but we need a function to set it back again when loading content.
