### PR TITLE
getText, setText multi-editor compatibility

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1538,13 +1538,13 @@ You should have received a copy of the GNU General Public License along with thi
 		
 		getText: function(){
 			//Function to get the source code.
-			var src = $('#contentarea').html();
+			var src = $($(this).parent()).find("#contentarea").html();
 			return src;
 		},
 
 		setText: function(text){
 			//Function to set the source code
-			$('#contentarea').html(text);
+			$($(this).parent()).find("#contentarea").html(text);
 		},
 
 		setStyleWithCSS:function(){


### PR DESCRIPTION
This modification allows getText and setText function to work when we are using more than 1 editor in the same page.
