### PR TITLE
Update editor.js : changed from ".andSelf()" to "addBack()"

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -1074,17 +1074,17 @@ You should have received a copy of the GNU General Public License along with thi
 	       	//For contextmenu	       	
 		    $(document.body).mousedown(function(event) {
 		        var target = $(event.target);
-		        if (!target.parents().andSelf().is('#context-menu')) { // Clicked outside
+		        if (!target.parents().addBack().is('#context-menu')) { // Clicked outside
 		            $('#context-menu').remove();
 		        } 
-		        if (!target.parents().andSelf().is('#specialchar') && (target.closest('a').html()!='<i class="fa fa-asterisk"></i>')) { //Clicked outside
+		        if (!target.parents().addBack().is('#specialchar') && (target.closest('a').html()!='<i class="fa fa-asterisk"></i>')) { //Clicked outside
 		        	if($("#specialchar").is(':visible'))
 		            {
 						$(editor_Content).data("editor").data("splcharsBtn", null);
 						$('#specialchar').remove();
 		           	}
 		        }
-		        if (!target.parents().andSelf().is('#paletteCntr') && (target.closest('a').html()!='<i class="fa fa-font"></i>')) { //Clicked outside
+		        if (!target.parents().addBack().is('#paletteCntr') && (target.closest('a').html()!='<i class="fa fa-font"></i>')) { //Clicked outside
 		        	if($("#paletteCntr").is(':visible'))
 		            {
 						$(editor_Content).data("editor").data("colorBtn", null);


### PR DESCRIPTION
Hi.. If any issues let me know..

.andSelf() was deprecated in jQuery 1.8 and removed in jQuery 3.0. .addBack() should be used instead from jQuery 1.8 onward.

